### PR TITLE
Alternate language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 WIP. Feedback wanted for [lua-nuspell](https://github.com/f3fora/lua-nuspell)
 
-Support only `en_US` dictionary.
-
 First test for integrating `nuspell` and hunspell dictionary into neovim.
 
 ## Setup
 
 ```lua
+vim.g.cmp_nuspell_lang = 'en_CA' -- optional, defaults to en_US
+
 require('cmp').setup {
   sources = {
     { name = 'nuspell' }

--- a/after/plugin/cmp-nuspell.lua
+++ b/after/plugin/cmp-nuspell.lua
@@ -1,1 +1,1 @@
-require('cmp').register_source('nuspell', require('cmp-nuspell').new())
+require('cmp').register_source('nuspell', require('cmp-nuspell').new(vim.g.cmp_nuspell_lang))

--- a/lua/cmp-nuspell/init.lua
+++ b/lua/cmp-nuspell/init.lua
@@ -1,16 +1,20 @@
 local nuspell = require('nuspell')
 local source = {}
 
-local lang = 'en_US'
-local dirs = nuspell.search_default_dirs_for_dicts()
-local path = nuspell.find_dictionary(dirs, lang)
+function source.new(lang)
+    if lang == nil then
+        lang = 'en_US'
+    end
+    local dirs = nuspell.search_default_dirs_for_dicts()
+    local path = nuspell.find_dictionary(dirs, lang)
 
-function source.new()
     local self = setmetatable({}, { __index = source })
     self.available = false
     if path then
         self.dict = nuspell.Dictionary.load_from_path(path)
         self.available = true
+    else
+        vim.cmd('echoerr "no dictionary found for language ' .. lang .. '"')
     end
     return self
 end


### PR DESCRIPTION
Hello! This PR adds support for selecting alternative languages via the global variable `cmp_nuspell_lang`. The default is `"en_US"`, so this won't cause a breaking change for existing users, though it also adds an error message when no dictionary is found, so that would be a breaking change for anyone who has the plugin installed but doesn't have a dictionary.

Let me know if there's anything you'd like me to change, or if there's a better way to allow configuration of the language.

Closes #1.